### PR TITLE
Repair fallout from Bug 1426494

### DIFF
--- a/dom/base/ChromeNodeList.cpp
+++ b/dom/base/ChromeNodeList.cpp
@@ -6,6 +6,7 @@
 
 #include "mozilla/dom/ChromeNodeList.h"
 #include "mozilla/dom/ChromeNodeListBinding.h"
+#include "nsPIDOMWindow.h"
 
 using namespace mozilla;
 using namespace mozilla::dom;

--- a/dom/base/ChromeNodeList.h
+++ b/dom/base/ChromeNodeList.h
@@ -6,6 +6,7 @@
 
 #include "nsCOMArray.h"
 #include "nsContentList.h"
+#include "nsIDocument.h"
 
 namespace mozilla {
 class ErrorResult;

--- a/dom/base/ShadowRoot.cpp
+++ b/dom/base/ShadowRoot.cpp
@@ -58,6 +58,7 @@ ShadowRoot::ShadowRoot(Element* aElement, bool aClosed,
                        already_AddRefed<mozilla::dom::NodeInfo>&& aNodeInfo,
                        nsXBLPrototypeBinding* aProtoBinding)
   : DocumentFragment(aNodeInfo)
+  , StyleScope(this) 
   , mProtoBinding(aProtoBinding)
   , mInsertionPointChanged(false)
   , mIsComposedDocParticipant(false)

--- a/dom/base/ShadowRoot.h
+++ b/dom/base/ShadowRoot.h
@@ -57,12 +57,6 @@ public:
     return mMode == ShadowRootMode::Closed;
   }
 
-  // StyleScope.
-  nsINode& AsNode() final
-  {
-    return *this;
-  }
-
   // [deprecated] Shadow DOM v0
   void InsertSheet(StyleSheet* aSheet, nsIContent* aLinkingContent);
   void RemoveSheet(StyleSheet* aSheet);

--- a/dom/base/StyleScope.cpp
+++ b/dom/base/StyleScope.cpp
@@ -7,9 +7,24 @@
 #include "StyleScope.h"
 #include "mozilla/dom/StyleSheetList.h"
 #include "XULDocument.h"
+#include "ShadowRoot.h"
+
+class nsINode;
+class nsIDocument;
+class mozilla::dom::ShadowRoot;
 
 namespace mozilla {
 namespace dom {
+
+StyleScope::StyleScope(mozilla::dom::ShadowRoot* aShadowRoot)
+  : mAsNode(aShadowRoot)
+  , mKind(Kind::ShadowRoot)
+{ MOZ_ASSERT(mAsNode); }
+
+StyleScope::StyleScope(nsIDocument* aDoc)
+  : mAsNode(aDoc)
+  , mKind(Kind::Document)
+{ MOZ_ASSERT(mAsNode); }
 
 StyleScope::~StyleScope()
 {

--- a/dom/base/StyleScope.h
+++ b/dom/base/StyleScope.h
@@ -11,6 +11,7 @@
 #include "nsIdentifierMapEntry.h"
 #include "nsContentListDeclarations.h"
 #include "nsNameSpaceManager.h"
+#include "mozilla/dom/NameSpaceConstants.h"
 
 class nsContentList;
 class nsINode;
@@ -32,12 +33,23 @@ class ShadowRoot;
  */
 class StyleScope
 {
+  enum class Kind {
+    Document,
+    ShadowRoot,
+  };
+
 public:
-  virtual nsINode& AsNode() = 0;
+  explicit StyleScope(nsIDocument*);
+  explicit StyleScope(mozilla::dom::ShadowRoot*);
+
+  nsINode& AsNode()
+  {
+    return *mAsNode;
+  }
 
   const nsINode& AsNode() const
   {
-    return const_cast<StyleScope&>(*this).AsNode();
+    return *mAsNode;
   }
 
   StyleSheet* SheetAt(size_t aIndex) const
@@ -116,6 +128,9 @@ protected:
    *    new ones for IDs.
    */
   nsTHashtable<nsIdentifierMapEntry> mIdentifierMap;
+
+  nsINode* mAsNode;
+  const Kind mKind;
 
 };
 

--- a/dom/base/nsDocument.cpp
+++ b/dom/base/nsDocument.cpp
@@ -300,24 +300,20 @@ GetHttpChannelHelper(nsIChannel* aChannel, nsIHttpChannel** aHttpChannel)
 
 #define NAME_NOT_VALID ((nsSimpleContentList*)1)
 
-nsIdentifierMapEntry::nsIdentifierMapEntry(const nsIdentifierMapEntry::AtomOrString& aKey)
-  : mKey(aKey)
+nsIdentifierMapEntry::nsIdentifierMapEntry(nsIdentifierMapEntry::KeyType aKey) :
+  nsStringHashKey(&aKey), mNameContentList(nullptr)
 {}
 
-nsIdentifierMapEntry::nsIdentifierMapEntry(const nsIdentifierMapEntry::AtomOrString* aKey)
-  : mKey(aKey ? *aKey : nullptr)
+nsIdentifierMapEntry::nsIdentifierMapEntry(nsIdentifierMapEntry::KeyTypePointer aKey)
+  : nsStringHashKey(aKey), mNameContentList(nullptr)
 {}
 
 nsIdentifierMapEntry::~nsIdentifierMapEntry()
 {}
 
-nsIdentifierMapEntry::nsIdentifierMapEntry(nsIdentifierMapEntry&& aOther)
-  : mKey(mozilla::Move(aOther.mKey))
-  , mIdContentList(mozilla::Move(aOther.mIdContentList))
-  , mNameContentList(mozilla::Move(aOther.mNameContentList))
-  , mChangeCallbacks(mozilla::Move(aOther.mChangeCallbacks))
-  , mImageElement(mozilla::Move(aOther.mImageElement))
-{}
+nsIdentifierMapEntry::nsIdentifierMapEntry(const nsIdentifierMapEntry& aOther)
+  : nsStringHashKey(&aOther.GetKey())
+{ NS_ERROR("Should never be called."); }
 
 void
 nsIdentifierMapEntry::Traverse(nsCycleCollectionTraversalCallback* aCallback)
@@ -1247,6 +1243,7 @@ static already_AddRefed<mozilla::dom::NodeInfo> nullNodeInfo;
 // ==================================================================
 nsIDocument::nsIDocument()
   : nsINode(nullNodeInfo),
+    StyleScope(this),
     mReferrerPolicySet(false),
     mReferrerPolicy(mozilla::net::RP_Default),
     mBlockAllMixedContent(false),

--- a/dom/base/nsIDocument.h
+++ b/dom/base/nsIDocument.h
@@ -1071,11 +1071,6 @@ public:
    */
   virtual void EnsureOnDemandBuiltInUASheet(mozilla::StyleSheet* aSheet) = 0;
 
-  nsINode& AsNode() final
-  {
-    return *this;
-  }
-
   mozilla::dom::StyleSheetList* StyleSheets()
   {
     return &StyleScope::EnsureDOMStyleSheets();

--- a/dom/base/nsIdentifierMapEntry.h
+++ b/dom/base/nsIdentifierMapEntry.h
@@ -57,10 +57,11 @@ class nsIdentifierMapEntry : public nsStringHashKey
    */
   typedef bool (* IDTargetObserver)(Element* aOldElement,
                                     Element* aNewelement, void* aData);
+
 public:
-  explicit nsIdentifierMapEntry(const nsAString& aKey);
-  explicit nsIdentifierMapEntry(const nsAString* aKey);
-  nsIdentifierMapEntry(nsIdentifierMapEntry&& aOther);
+  explicit nsIdentifierMapEntry(KeyType aKey);
+  explicit nsIdentifierMapEntry(KeyTypePointer aKey);
+  nsIdentifierMapEntry(const nsIdentifierMapEntry& aOther);
   ~nsIdentifierMapEntry();
 
   void AddNameElement(nsINode* aDocument, Element* aElement);

--- a/dom/base/nsNameSpaceManager.h
+++ b/dom/base/nsNameSpaceManager.h
@@ -10,13 +10,13 @@
 #include "nsDataHashtable.h"
 #include "nsHashKeys.h"
 #include "nsIAtom.h"
-#include "nsIDocument.h"
 #include "nsIObserver.h"
 #include "nsTArray.h"
 
 #include "mozilla/StaticPtr.h"
 
 class nsAString;
+class nsIDocument;
 
 /**
  * The Name Space Manager tracks the association between a NameSpace

--- a/security/nss/coreconf/SunOS5.mk
+++ b/security/nss/coreconf/SunOS5.mk
@@ -23,7 +23,7 @@ ifeq ($(USE_64), 1)
 else
   ifneq ($(OS_TEST),i86pc)
     ifdef NS_USE_GCC
-      ARCHFLAG=-mcpu=v9
+      ARCHFLAG=-m32
     else
       ARCHFLAG=-xarch=v8plus
     endif


### PR DESCRIPTION
I'm not sure what exactly happened to cause the circular header dependency issues, but I seem to have resolved them anyway. I also wound up needing the devirtualize part of the patch because the way the "Share more code" part is structured depends on it.

As for the rest of the bug, here is how I got this working. Look closely at the original bug and notice that it's moving code around pretty much intact, but the way the patch was applied here removes old code and replaces it with much newer Firefox code that hasn't been adapted to UXP.

https://bugzilla.mozilla.org/show_bug.cgi?id=1217436

Specifically we didn't have this, and all it did was change an nsTArray to an AutoTArray and added no new functionality whatsoever. So I accounted for us not having it. It makes it really obvious what the missing callbacks/prototypes are when you understand what this patch did and how we got half of it inadvertantly when moving code between nsIdentifierMapEntry and nsDocument.

https://bugzilla.mozilla.org/show_bug.cgi?id=1355787

This is where AtomOrString comes from, and it appears we don't technically need this patch for this bug if we use KeyType and KeyTypePointer here.

https://bugzilla.mozilla.org/show_bug.cgi?id=1597715

And I also had to apply this bug because the SunOS libc didn't like the undefined behavior they were using here. I'm not sure if this would be an issue on other operating systems.

This probably needs to be split out into three different commits, I'm just writing this note to you so you can see what I did and use the information for yourself to decide how best to proceed.

Good luck, G4JC.